### PR TITLE
Encode namespaces for sealed traits using element names as discriminators

### DIFF
--- a/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/EncoderDerivation.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/EncoderDerivation.scala
@@ -41,7 +41,7 @@ class EncoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
 
       cq"""sub: ${subtype.subtypeType.resultType} =>
              if ($config.useElementNameAsDiscriminator) {
-               $ref.encodeAsElement(sub, sw, ${subtype.constructorName}, $scalaPkg.None)
+               $ref.encodeAsElement(sub, sw, ${subtype.constructorName}, namespaceUri)
              } else {
                sw.memorizeDiscriminator($config.discriminatorNamespace, $config.discriminatorLocalName, ${subtype.constructorName})
                $ref.encodeAsElement(sub, sw, localName, namespaceUri)

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/EncoderDerivationTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/EncoderDerivationTest.scala
@@ -1096,6 +1096,50 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       """.stripMargin.minimized,
       )
     }
+
+    "encode sealed traits" in {
+      @XmlnsDef("tinkoff.ru")
+      case object tkf
+
+      @XmlCodec("aquarium", ElementCodecConfig.default.withNamespaceDefined(tkf))
+      case class Aquarium(@xmlns(tkf) fish: List[SealedClasses.Pisces])
+      val string =
+        """<?xml version='1.0' encoding='UTF-8'?>
+          | <aquarium xmlns:ans1="tinkoff.ru">
+          |   <ans1:fish xmlns:ans2="http://www.w3.org/2001/XMLSchema-instance" ans2:type="ClownFish">
+          |     <name>Marlin</name>
+          |     <finNumber>3</finNumber>
+          |   </ans1:fish>
+          |   <ans1:fish xmlns:ans3="http://www.w3.org/2001/XMLSchema-instance" ans3:type="carcharodon_carcharias">
+          |     <name>Jaws</name>
+          |     <teethNumber>1234</teethNumber>
+          |   </ans1:fish>
+          | </aquarium>
+          |""".stripMargin.minimized
+      val aquarium = Aquarium(List(SealedClasses.Amphiprion("Marlin", 3), SealedClasses.CarcharodonCarcharias("Jaws", 1234)))
+      XmlEncoder[Aquarium].encode(aquarium) shouldBe string
+    }
+
+    "encode sealed traits using element names as discriminators" in {
+      @XmlnsDef("tinkoff.ru")
+      case object tkf
+
+      @XmlCodec("shelter", ElementCodecConfig.default.withNamespaceDefined(tkf))
+      case class AnimalShelter(@xmlns(tkf) animals: List[SealedClasses.Animal])
+      val string =
+        """<?xml version='1.0' encoding='UTF-8'?>
+          | <shelter xmlns:ans1="tinkoff.ru">
+          |   <ans1:cat>
+          |     <meow>meow</meow>
+          |   </ans1:cat>
+          |   <ans1:dog>
+          |     <woof>1234</woof>
+          |   </ans1:dog>
+          | </shelter>
+        """.stripMargin.minimized
+      val animalShelter = AnimalShelter(List(Cat("meow"), Dog(1234)))
+      XmlEncoder[AnimalShelter].encode(animalShelter) shouldBe string
+    }
   }
 
   "Encoder derivation compilation" should {


### PR DESCRIPTION
Fixes #173. Uses namespace configured either with `@xmlns` or `elementsDefaultNamespace` when encoding sealed traits using element names as discriminators.