### PR TITLE
Change codecs for Unit

### DIFF
--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/ElementDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/ElementDecoder.scala
@@ -154,7 +154,7 @@ object ElementDecoder extends ElementLiteralInstances with DerivedElement {
 
   implicit val stringDecoder: ElementDecoder[String] = new StringDecoder()
 
-  implicit val unitDecoder: ElementDecoder[Unit] = new ConstDecoder[Unit](())
+  implicit val unitDecoder: ElementDecoder[Unit] = stringDecoder.map(_ => ())
 
   implicit val booleanDecoder: ElementDecoder[Boolean] =
     stringDecoder.emap((history, string) =>

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/TextDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/TextDecoder.scala
@@ -106,7 +106,7 @@ object TextDecoder extends TextLiteralInstances {
 
   implicit val stringDecoder: TextDecoder[String] = new StringDecoder()
 
-  implicit val unitDecoder: TextDecoder[Unit] = new ConstDecoder[Unit](())
+  implicit val unitDecoder: TextDecoder[Unit] = stringDecoder.map(_ => ())
 
   implicit val booleanDecoder: TextDecoder[Boolean] =
     stringDecoder.emap((history, string) =>

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/ElementEncoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/ElementEncoder.scala
@@ -45,7 +45,8 @@ object ElementEncoder extends ElementLiteralInstances with DerivedElement {
 
   implicit val unitEncoder: ElementEncoder[Unit] =
     new ElementEncoder[Unit] {
-      def encodeAsElement(a: Unit, sw: PhobosStreamWriter, localName: String, namespaceUri: Option[String]): Unit = ()
+      def encodeAsElement(a: Unit, sw: PhobosStreamWriter, localName: String, namespaceUri: Option[String]): Unit =
+        namespaceUri.fold(sw.writeEmptyElement(localName))(ns => sw.writeEmptyElement(ns, localName))
     }
 
   implicit val booleanEncoder: ElementEncoder[Boolean]                     = stringEncoder.contramap(_.toString)
@@ -81,7 +82,11 @@ object ElementEncoder extends ElementLiteralInstances with DerivedElement {
 
   implicit def someEncoder[A](implicit e: ElementEncoder[A]): ElementEncoder[Some[A]] = e.contramap(_.get)
 
-  implicit val noneEncoder: ElementEncoder[None.type] = unitEncoder.contramap(_ => ())
+  implicit val noneEncoder: ElementEncoder[None.type] =
+    new ElementEncoder[None.type] {
+      def encodeAsElement(a: None.type, sw: PhobosStreamWriter, localName: String, namespaceUri: Option[String]): Unit =
+        ()
+    }
 
   implicit def iteratorEncoder[A](implicit encoder: ElementEncoder[A]): ElementEncoder[Iterator[A]] =
     new ElementEncoder[Iterator[A]] {


### PR DESCRIPTION
Changes for encoders and decoders of Unit type, as suggested by @FrancisToth.

----

Case class `Bar`
```scala
case class Bar(flag: Unit) derives ElementDecoder
XmlEncoder.fromElementEncoder[Bar]("bar").encode(Bar())
```
was previously encoded to
```xml
<bar/>
```
now it is encoded to
```xml
<bar><flag/></bar>
```

---

Decoding of `Bar` now succeeds on
```xml
<bar><flag/></bar>
```
and fails on
```xml
<bar/>
```
Previously it behaved the opposite 