### PR TITLE
Fix scope namespaces for lists

### DIFF
--- a/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/DecoderDerivation.scala
+++ b/modules/core/src/main/scala-2/ru/tinkoff/phobos/derivation/DecoderDerivation.scala
@@ -326,7 +326,7 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
                       $classConstruction match {
                         case $scalaPkg.Right(result) =>
                           cursor.next()
-                          cursor.unsetScopeDefaultNamespace()
+                          $config.scopeDefaultNamespace.foreach(_ => cursor.unsetScopeDefaultNamespace())
                           new $decodingPkg.ElementDecoder.ConstDecoder[$classType](result)
 
                         case $scalaPkg.Left(error) =>

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/decoder.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/decoder.scala
@@ -181,6 +181,7 @@ object decoder {
     c: Expr[Cursor],
     localName: Expr[String],
     currentFieldStates: Expr[mutable.AnyRefMap[String, Any]],
+    config: Expr[ElementCodecConfig],
   ) = {
     import quotes.reflect.*
 
@@ -243,7 +244,7 @@ object decoder {
         } match {
           case Right(result) =>
             $c.next()
-            $c.unsetScopeDefaultNamespace()
+            $config.scopeDefaultNamespace.foreach(_ => $c.unsetScopeDefaultNamespace())
             new ConstDecoder[T](result)
           case Left(error) =>
             new FailedDecoder[T](error)
@@ -359,7 +360,7 @@ object decoder {
                 if (c.isStartElement) {
                   ${decodeStartElement[T](groups, 'go, 'c, 'currentFieldStates)}
                 } else if (c.isEndElement) {
-                  ${decodeEndElement[T](fields, 'go, 'c, 'localName, 'currentFieldStates)}
+                  ${decodeEndElement[T](fields, 'go, 'c, 'localName, 'currentFieldStates, config)}
                 } else {
                   c.next()
                   go(DecoderState.DecodingSelf)

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/DecoderDerivationTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/DecoderDerivationTest.scala
@@ -1455,10 +1455,14 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       case object tcs
       implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
 
+      final case class Qux(g: String, h: Int)
+      implicit val quxDecoder: ElementDecoder[Qux] = deriveElementDecoder
+
       final case class Foo(
           d: Int,
           @xmlns(tcs) e: String,
           f: Double,
+          qux: List[Qux]
       )
       implicit val fooEncoder: ElementDecoder[Foo] = deriveElementDecoder
 
@@ -1466,7 +1470,7 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       val config                               = ElementCodecConfig.default.withScopeDefaultNamespace(tkf)
       implicit val barEncoder: XmlDecoder[Bar] = deriveXmlDecoderConfigured("bar", config)
 
-      val bar = Bar(123, "b value", 1.234, Foo(321, "e value", 4.321))
+      val bar = Bar(123, "b value", 1.234, Foo(321, "e value", 4.321, List(Qux("g value 1", 1), Qux("g value 2", 2))))
       val string1 =
         """<?xml version='1.0' encoding='UTF-8'?>
           | <bar xmlns="tinkoff.ru">
@@ -1477,6 +1481,14 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
           |     <d>321</d>
           |     <ans2:e xmlns:ans2="tcsbank.ru">e value</ans2:e>
           |     <f>4.321</f>
+          |     <qux>
+          |       <g>g value 1</g>
+          |       <h>1</h>
+          |     </qux>
+          |     <qux>
+          |       <g>g value 2</g>
+          |       <h>2</h>
+          |     </qux>
           |   </foo>
           | </bar>
           |""".stripMargin
@@ -1491,6 +1503,14 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
           |     <ans1:d>321</ans1:d>
           |     <ans2:e>e value</ans2:e>
           |     <ans1:f>4.321</ans1:f>
+          |     <ans1:qux>
+          |       <ans1:g>g value 1</ans1:g>
+          |       <ans1:h>1</ans1:h>
+          |     </ans1:qux>
+          |     <ans1:qux>
+          |       <ans1:g>g value 2</ans1:g>
+          |       <ans1:h>2</ans1:h>
+          |     </ans1:qux>
           |   </ans1:foo>
           | </ans1:bar>
           |""".stripMargin

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/EncoderDerivationTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/EncoderDerivationTest.scala
@@ -1259,10 +1259,14 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       case object tcs
       implicit val tcsNs: Namespace[tcs.type] = Namespace.mkInstance("tcsbank.ru")
 
+      final case class Qux(g: String, h: Int)
+      implicit val quxEncoder: ElementEncoder[Qux] = deriveElementEncoder
+
       final case class Foo(
           d: Int,
           @xmlns(tcs) e: String,
           f: Double,
+          qux: List[Qux],
       )
       implicit val fooEncoder: ElementEncoder[Foo] = deriveElementEncoder
 
@@ -1270,7 +1274,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val config                               = ElementCodecConfig.default.withScopeDefaultNamespace(tkf)
       implicit val barEncoder: XmlEncoder[Bar] = deriveXmlEncoderConfigured("bar", config)
 
-      val bar    = Bar(123, "b value", 1.234, Foo(321, "e value", 4.321))
+      val bar    = Bar(123, "b value", 1.234, Foo(321, "e value", 4.321, List(Qux("g value 1", 1), Qux("g value 2", 2))))
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
@@ -1283,6 +1287,14 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
           |     <d>321</d>
           |     <ans2:e xmlns:ans2="tcsbank.ru">e value</ans2:e>
           |     <f>4.321</f>
+          |     <qux>
+          |       <g>g value 1</g>
+          |       <h>1</h>
+          |     </qux>
+          |     <qux>
+          |       <g>g value 2</g>
+          |       <h>2</h>
+          |     </qux>
           |   </foo>
           | </bar>
           |""".stripMargin.minimized,


### PR DESCRIPTION
This PR fixes a bug, that was introduced in https://github.com/Tinkoff/phobos/pull/256. Scope namespaces now work correctly with lists