### PR TITLE
More secure encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ val journey =
     arrival = TravelPoint("Germany", "Munich")
   )
 
-val xml: String = XmlEncoder[Journey].encode(journey)
+val xml = XmlEncoder[Journey].encode(journey)
 println(xml)
 
-val decodedJourney = XmlDecoder[Journey].decode(xml)
+val decodedJourney = xml.flatMap(XmlDecoder[Journey].decode(_))
 println(decodedJourney)
 
 assert(Right(journey) == decodedJourney)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@
 
 ThisBuild / name := "phobos"
 
-ThisBuild / scalaVersion := "3.1.2"
+ThisBuild / scalaVersion := "3.2.1"
 
 lazy val commonDependencies =
   libraryDependencies ++=

--- a/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/marshalling/application.scala
+++ b/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/marshalling/application.scala
@@ -9,7 +9,7 @@ import ru.tinkoff.phobos.encoding.XmlEncoder
 object application {
   implicit def soapApplicationXmlMarshaller[T](implicit encoder: XmlEncoder[T]): ToEntityMarshaller[T] =
     Marshaller.withFixedContentType(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`) { body =>
-      HttpEntity(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`, encoder.encode(body))
+      HttpEntity(MediaTypes.`application/xml` withCharset HttpCharsets.`UTF-8`, encoder.encodeUnsafe(body))
     }
 
   implicit def soapApplicationXmlUnmarshaller[T](implicit decoder: XmlDecoder[T]): FromEntityUnmarshaller[T] =

--- a/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/marshalling/text.scala
+++ b/modules/akka-http/src/main/scala/ru/tinkoff/phobos/akka_http/marshalling/text.scala
@@ -10,7 +10,7 @@ import ru.tinkoff.phobos.encoding.XmlEncoder
 object text {
   implicit def soapTextXmlMarshaller[T](implicit encoder: XmlEncoder[T]): ToEntityMarshaller[T] =
     Marshaller.withFixedContentType(`text/xml(UTF-8)`) { body =>
-      HttpEntity(`text/xml(UTF-8)`, encoder.encode(body))
+      HttpEntity(`text/xml(UTF-8)`, encoder.encodeUnsafe(body))
     }
 
   implicit def soapTextXmlUnmarshaller[T](implicit decoder: XmlDecoder[T]): FromEntityUnmarshaller[T] =

--- a/modules/akka-stream/src/main/scala/ru/tinkoff/phobos/ops/AkkaStreamOps.scala
+++ b/modules/akka-stream/src/main/scala/ru/tinkoff/phobos/ops/AkkaStreamOps.scala
@@ -39,7 +39,7 @@ private[phobos] trait AkkaStreamOps {
       }
       .map {
         case None =>
-          throw DecodingError("Got an internal error while decoding byte stream", Nil)
+          throw DecodingError("Got an internal error while decoding byte stream", Nil, None)
 
         case Some(SinkDecoderState(_, cursor, elementDecoder)) =>
           elementDecoder.result(cursor.history)

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/CodecProperties.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/CodecProperties.scala
@@ -13,15 +13,12 @@ class CodecProperties extends Properties("Ast codecs") {
   private val decoder = XmlDecoder.fromElementDecoder[XmlEntry]("test")
 
   property("decode(encode(ast)) === ast") = forAll { entry: XmlEntry =>
-    decoder.decode(
-      encoder.encode(entry),
-    ) == Right(entry)
+    encoder.encode(entry).flatMap(decoder.decode(_)) == Right(entry)
   }
 
   property("encode(decode(xmlAst)) === xmlAst") = forAll { entry: XmlEntry =>
     val encoded = encoder.encode(entry)
-
-    decoder.decode(encoded).map(encoder.encode(_)) == Right(encoded)
+    encoded.flatMap(decoder.decode(_)).map(encoder.encode(_)) == Right(encoded)
   }
 }
 

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/XmlEntryElementDecoderTest.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/XmlEntryElementDecoderTest.scala
@@ -60,15 +60,9 @@ class XmlEntryElementDecoderTest extends AnyWordSpec with Matchers with DiffShou
 
       val encoded = ru.tinkoff.phobos.encoding.XmlEncoder.fromElementEncoder[XmlEntry]("ast").encode(n)
 
-      val result = XmlDecoder
-        .fromElementDecoder[XmlEntry]("ast")
-        .decode(
-          encoded,
-        )
+      val result = encoded.flatMap(XmlDecoder.fromElementDecoder[XmlEntry]("ast").decode(_))
 
-      result.map(util.AstTransformer.sortNodeValues) shouldMatchTo (
-        util.AstTransformer.sortNodeValues(n).asRight[DecodingError]
-      )
+      assert(result.map(util.AstTransformer.sortNodeValues) == Right(util.AstTransformer.sortNodeValues(n)))
     }
   }
 }

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/XmlEntryElementEncoderTest.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/XmlEntryElementEncoderTest.scala
@@ -16,7 +16,7 @@ class XmlEntryElementEncoderTest extends AnyWordSpec with DiffShouldMatcher with
           .fromElementEncoder[XmlEntry]("ast")
           .encode(ast)
 
-      assert(result == """<?xml version='1.0' encoding='UTF-8'?><ast foo="5"><bar>bazz</bar></ast>""")
+      assert(result == Right("""<?xml version='1.0' encoding='UTF-8'?><ast foo="5"><bar>bazz</bar></ast>"""))
     }
     "encodes nested Xml ast correctly" in {
       case object tinkoff {
@@ -46,7 +46,9 @@ class XmlEntryElementEncoderTest extends AnyWordSpec with DiffShouldMatcher with
           .encode(ast)
 
       assert(
-        result == """<?xml version='1.0' encoding='UTF-8'?><ans1:ast xmlns:ans1="https://tinkoff.ru" foo="5"><bar>bazz</bar><array foo2="true" foo3="false"><elem>11111111111111</elem><elem>11111111111112</elem></array><nested><scala>2.13</scala><dotty>0.13</dotty><scala-4/></nested></ans1:ast>""",
+        result == Right(
+          """<?xml version='1.0' encoding='UTF-8'?><ans1:ast xmlns:ans1="https://tinkoff.ru" foo="5"><bar>bazz</bar><array foo2="true" foo3="false"><elem>11111111111111</elem><elem>11111111111112</elem></array><nested><scala>2.13</scala><dotty>0.13</dotty><scala-4/></nested></ans1:ast>""",
+        ),
       )
     }
   }

--- a/modules/cats/src/main/scala/ru/tinkoff/phobos/catsInstances.scala
+++ b/modules/cats/src/main/scala/ru/tinkoff/phobos/catsInstances.scala
@@ -62,21 +62,25 @@ object catsInstances {
     listDecoder[A].emap((history, list) =>
       NonEmptyList
         .fromList(list)
-        .fold[Either[DecodingError, NonEmptyList[A]]](Left(DecodingError("List is empty", history)))(Right.apply),
+        .fold[Either[DecodingError, NonEmptyList[A]]](Left(DecodingError("List is empty", history, None)))(Right.apply),
     )
 
   implicit def nonEmptyVectorElementDecoder[A](implicit decoder: ElementDecoder[A]): ElementDecoder[NonEmptyVector[A]] =
     vectorDecoder[A].emap((history, vector) =>
       NonEmptyVector
         .fromVector(vector)
-        .fold[Either[DecodingError, NonEmptyVector[A]]](Left(DecodingError("Vector is empty", history)))(Right.apply),
+        .fold[Either[DecodingError, NonEmptyVector[A]]](Left(DecodingError("Vector is empty", history, None)))(
+          Right.apply,
+        ),
     )
 
   implicit def nonEmptyChainElementDecoder[A](implicit decoder: ElementDecoder[A]): ElementDecoder[NonEmptyChain[A]] =
     chainElementDecoder[A].emap((history, chain) =>
       NonEmptyChain
         .fromChain(chain)
-        .fold[Either[DecodingError, NonEmptyChain[A]]](Left(DecodingError("Chain is empty", history)))(Right.apply),
+        .fold[Either[DecodingError, NonEmptyChain[A]]](Left(DecodingError("Chain is empty", history, None)))(
+          Right.apply,
+        ),
     )
 
   implicit class XmlDecoderCatsOps[A](val xmlDecoder: XmlDecoder[A]) extends AnyVal {

--- a/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/AttributeLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/AttributeLiteralInstances.scala
@@ -8,6 +8,7 @@ private[decoding] trait AttributeLiteralInstances {
     decoder
       .emap((history, a) =>
         if (a == valueOfL.value) Right(valueOfL.value)
-        else Left(DecodingError(s"Failed to decode literal type. Expected: ${valueOfL.value}, actual: $a", history)),
+        else
+          Left(DecodingError(s"Failed to decode literal type. Expected: ${valueOfL.value}, actual: $a", history, None)),
       )
 }

--- a/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/ElementLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/ElementLiteralInstances.scala
@@ -5,6 +5,6 @@ private[decoding] trait ElementLiteralInstances {
     decoder
       .emap((history, a) =>
         if (a == valueOfL.value) Right(valueOfL.value)
-        else Left(DecodingError(s"Failed to decode literal type. Expected: ${valueOfL.value}, actual: $a", history)),
+        else Left(DecodingError(s"Failed to decode literal type. Expected: ${valueOfL.value}, actual: $a", history, None)),
       )
 }

--- a/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/TextLiteralInstances.scala
+++ b/modules/core/src/main/scala-2.13/ru/tinkoff/phobos/decoding/TextLiteralInstances.scala
@@ -5,6 +5,7 @@ private[decoding] trait TextLiteralInstances {
     decoder
       .emap((history, a) =>
         if (a == valueOfL.value) Right(valueOfL.value)
-        else Left(DecodingError(s"Failed to decode literal type. Expected: ${valueOfL.value}, actual: $a", history)),
+        else
+          Left(DecodingError(s"Failed to decode literal type. Expected: ${valueOfL.value}, actual: $a", history, None)),
       )
 }

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/AttributeLiteralInstances.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/AttributeLiteralInstances.scala
@@ -8,6 +8,6 @@ private[decoding] trait AttributeLiteralInstances {
     decoder
       .emap((history, a) =>
         if (a == valueOfL.value) Right(valueOfL.value)
-        else Left(DecodingError(s"Failed to decode literal type. Expected: ${valueOfL.value}, actual: $a", history)),
+        else Left(DecodingError(s"Failed to decode literal type. Expected: ${valueOfL.value}, actual: $a", history, None)),
       )
 }

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/ElementLiteralInstances.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/ElementLiteralInstances.scala
@@ -5,6 +5,6 @@ private[decoding] trait ElementLiteralInstances {
     decoder
       .emap((history, a) =>
         if (a == valueOfL.value) Right(valueOfL.value)
-        else Left(DecodingError(s"Failed to decode literal type. Expected: ${valueOfL.value}, actual: $a", history)),
+        else Left(DecodingError(s"Failed to decode literal type. Expected: ${valueOfL.value}, actual: $a", history, None)),
       )
 }

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/TextLiteralInstances.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/decoding/TextLiteralInstances.scala
@@ -5,6 +5,6 @@ private[decoding] trait TextLiteralInstances {
     decoder
       .emap((history, a) =>
         if (a == valueOfL.value) Right(valueOfL.value)
-        else Left(DecodingError(s"Failed to decode literal type. Expected: ${valueOfL.value}, actual: $a", history)),
+        else Left(DecodingError(s"Failed to decode literal type. Expected: ${valueOfL.value}, actual: $a", history, None)),
       )
 }

--- a/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/decoder.scala
+++ b/modules/core/src/main/scala-3/ru/tinkoff/phobos/derivation/decoder.scala
@@ -228,7 +228,7 @@ object decoder {
                         $currentFieldStates
                           .getOrElse(
                             ${Expr(field.localName)},
-                            Left(DecodingError(s"Attribute '${${field.xmlName}}' is missing or invalid", $c.history))
+                            Left(DecodingError(s"Attribute '${${field.xmlName}}' is missing or invalid", $c.history, None))
                           )
                           .asInstanceOf[Either[DecodingError, t]]
                           .flatMap { ${f.asExprOf[t => Either[DecodingError, T]]} }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/AttributeDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/AttributeDecoder.scala
@@ -64,7 +64,7 @@ object AttributeDecoder extends AttributeLiteralInstances {
       string match {
         case "true" | "1"  => Right(true)
         case "false" | "0" => Right(false)
-        case str           => Left(DecodingError(s"Value `$str` is not `true` or `false`", history))
+        case str           => Left(DecodingError(s"Value `$str` is not `true` or `false`", history, None))
       },
     )
 
@@ -73,7 +73,7 @@ object AttributeDecoder extends AttributeLiteralInstances {
   implicit val charDecoder: AttributeDecoder[Char] =
     stringDecoder.emap((history, string) => {
       if (string.length != 1) {
-        Left(DecodingError("Value too long for char", history))
+        Left(DecodingError("Value too long for char", history, None))
       } else {
         Right(string.head)
       }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/Cursor.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/Cursor.scala
@@ -32,7 +32,7 @@ class Cursor(private val sr: XmlStreamReader) {
   def hasNext: Boolean = sr.hasNext
 
   def history: List[String]              = historyStack
-  def error(text: String): DecodingError = DecodingError(text, historyStack)
+  def error(text: String): DecodingError = DecodingError(text, historyStack, None)
 
   var scopeDefaultNamespaceStack: List[String] = Nil
   def setScopeDefaultNamespace(uri: String): Unit = {

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/DecodingError.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/DecodingError.scala
@@ -1,6 +1,7 @@
 package ru.tinkoff.phobos.decoding
 
-case class DecodingError(text: String, history: List[String]) extends Exception {
+case class DecodingError(text: String, history: List[String], cause: Option[Throwable])
+    extends Exception(cause.orNull) {
   override def getMessage: String = {
     val trace = if (history.nonEmpty) {
       history.mkString("\tIn element '", "'\n\t\tin element '", "'")

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/ElementDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/ElementDecoder.scala
@@ -58,8 +58,8 @@ object ElementDecoder extends ElementLiteralInstances with DerivedElement {
 
   def decodingNotCompleteError(history: List[String]): DecodingError =
     history match {
-      case element :: others => DecodingError(s"Element '$element' is missing or invalid", others)
-      case Nil               => DecodingError("Root element is missing or invalid", Nil)
+      case element :: others => DecodingError(s"Element '$element' is missing or invalid", others, None)
+      case Nil               => DecodingError("Root element is missing or invalid", Nil, None)
     }
 
   final class MappedDecoder[A, B](fa: ElementDecoder[A], f: A => B) extends ElementDecoder[B] {
@@ -161,7 +161,7 @@ object ElementDecoder extends ElementLiteralInstances with DerivedElement {
       string match {
         case "true" | "1"  => Right(true)
         case "false" | "0" => Right(false)
-        case str           => Left(DecodingError(s"Value `$str` is not `true` or `false`", history))
+        case str           => Left(DecodingError(s"Value `$str` is not `true` or `false`", history, None))
       },
     )
 
@@ -170,7 +170,7 @@ object ElementDecoder extends ElementLiteralInstances with DerivedElement {
   implicit val charDecoder: ElementDecoder[Char] =
     stringDecoder.emap((history, string) => {
       if (string.length != 1) {
-        Left(DecodingError("Value too long for char", history))
+        Left(DecodingError("Value too long for char", history, None))
       } else {
         Right(string.head)
       }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/TextDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/TextDecoder.scala
@@ -113,7 +113,7 @@ object TextDecoder extends TextLiteralInstances {
       string match {
         case "true" | "1"  => Right(true)
         case "false" | "0" => Right(false)
-        case str           => Left(DecodingError(s"Value `$str` is not `true` or `false`", history))
+        case str           => Left(DecodingError(s"Value `$str` is not `true` or `false`", history, None))
       },
     )
 
@@ -122,7 +122,7 @@ object TextDecoder extends TextLiteralInstances {
   implicit val charDecoder: TextDecoder[Char] =
     stringDecoder.emap((history, string) => {
       if (string.length != 1) {
-        Left(DecodingError("Value too long for char", history))
+        Left(DecodingError("Value too long for char", history, None))
       } else {
         Right(string.head)
       }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/XmlDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/XmlDecoder.scala
@@ -42,8 +42,8 @@ trait XmlDecoder[A] extends XmlDecoderIterable[A] {
         .decodeAsElement(cursor, localname, namespaceuri)
         .result(cursor.history)
     } catch {
-      case e: WFCException =>
-        Left(DecodingError(e.getMessage, cursor.history))
+      case e: Throwable =>
+        Left(DecodingError(Option(e.getMessage).getOrElse("No message provided"), cursor.history))
     }
   }
 

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/XmlDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/XmlDecoder.scala
@@ -1,7 +1,7 @@
 package ru.tinkoff.phobos.decoding
 
 import javax.xml.stream.XMLStreamConstants
-import com.fasterxml.aalto.{AsyncByteArrayFeeder, WFCException}
+import com.fasterxml.aalto.AsyncByteArrayFeeder
 import com.fasterxml.aalto.async.{AsyncByteArrayScanner, AsyncStreamReaderImpl}
 import com.fasterxml.aalto.stax.InputFactoryImpl
 import ru.tinkoff.phobos.Namespace
@@ -43,7 +43,7 @@ trait XmlDecoder[A] extends XmlDecoderIterable[A] {
         .result(cursor.history)
     } catch {
       case e: Throwable =>
-        Left(DecodingError(Option(e.getMessage).getOrElse("No message provided"), cursor.history))
+        Left(DecodingError(Option(e.getMessage).getOrElse("No message provided"), cursor.history, Some(e)))
     }
   }
 

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/package.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/package.scala
@@ -10,7 +10,8 @@ package object decoding {
   private[decoding] def wrapException[A](f: String => A) =
     (history: List[String], string: String) =>
       Try(f(string)) match {
-        case Failure(exception) => Left(DecodingError(exception.getMessage, history))
-        case Success(a)         => Right(a)
+        case Failure(exception) =>
+          Left(DecodingError(Option(exception.getMessage).getOrElse("No text provided"), history, Some(exception)))
+        case Success(a) => Right(a)
       }
 }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/EncodingError.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/EncodingError.scala
@@ -1,0 +1,5 @@
+package ru.tinkoff.phobos.encoding
+
+case class EncodingError(text: String, cause: Option[Throwable] = None) extends Exception(text, cause.orNull) {
+  override def getMessage: String = s"Error while decoding XML: $text"
+}

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/PhobosStreamWriter.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/PhobosStreamWriter.scala
@@ -6,7 +6,7 @@ import javax.xml.stream.XMLStreamException
 import org.codehaus.stax2.typed.Base64Variant
 import org.codehaus.stax2.{XMLStreamLocation2, XMLStreamReader2, XMLStreamWriter2}
 import org.codehaus.stax2.validation.{ValidationProblemHandler, XMLValidationSchema, XMLValidator}
-import PhobosStreamWriter.{isValidXmlCharacter, prefixBase}
+import PhobosStreamWriter.prefixBase
 
 /** [[PhobosStreamWriter]] implements most methods of [[XMLStreamWriter2]], but it does not extends [[XMLStreamWriter2]]
   *

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/TextEncoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/TextEncoder.scala
@@ -28,7 +28,7 @@ object TextEncoder extends TextLiteralInstances {
     */
   implicit val stringEncoder: TextEncoder[String] =
     new TextEncoder[String] {
-      def encodeAsText(a: String, sw: PhobosStreamWriter): Unit = sw.writeRaw(a)
+      def encodeAsText(a: String, sw: PhobosStreamWriter): Unit = sw.writeCharacters(a)
     }
 
   implicit val unitEncoder: TextEncoder[Unit] =

--- a/modules/core/src/test/scala-2.13/ru/tinkoff/phobos/LiteralDecodingTest.scala
+++ b/modules/core/src/test/scala-2.13/ru/tinkoff/phobos/LiteralDecodingTest.scala
@@ -41,7 +41,7 @@ class LiteralDecodingTest extends AnyWordSpec with Matchers {
         """.stripMargin
       val decoded = XmlDecoder[Foo].decodeFromIterable(toList(string))
       decoded should
-        matchPattern { case Left(DecodingError("Failed to decode literal type. Expected: Ok, actual: Error", _)) => }
+        matchPattern { case Left(DecodingError("Failed to decode literal type. Expected: Ok, actual: Error", _, _)) => }
     }
 
     "fail on attributes with incorrect value sync" in failOnAttributesWithIncorrectValue(pure)
@@ -75,7 +75,7 @@ class LiteralDecodingTest extends AnyWordSpec with Matchers {
         """.stripMargin
       val decoded = XmlDecoder[Foo].decodeFromIterable(toList(string))
       decoded should
-        matchPattern { case Left(DecodingError("Failed to decode literal type. Expected: Ok, actual: Error", _)) => }
+        matchPattern { case Left(DecodingError("Failed to decode literal type. Expected: Ok, actual: Error", _, _)) => }
     }
 
     "fail on elements with incorrect value sync" in failOnElementsWithIncorrectValue(pure)
@@ -109,7 +109,7 @@ class LiteralDecodingTest extends AnyWordSpec with Matchers {
         """.stripMargin
       val decoded = XmlDecoder[Foo].decodeFromIterable(toList(string))
       decoded should
-        matchPattern { case Left(DecodingError("Failed to decode literal type. Expected: Ok, actual: Error", _)) => }
+        matchPattern { case Left(DecodingError("Failed to decode literal type. Expected: Ok, actual: Error", _, _)) => }
     }
 
     "fail on elements with incorrect value sync" in failOnElementsWithIncorrectValue(pure)

--- a/modules/core/src/test/scala-2.13/ru/tinkoff/phobos/LiteralEncodingTest.scala
+++ b/modules/core/src/test/scala-2.13/ru/tinkoff/phobos/LiteralEncodingTest.scala
@@ -15,9 +15,9 @@ class LiteralEncodingTest extends AnyWordSpec {
       val string = XmlEncoder[Foo].encode(Foo("Ok"))
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
             | <foo status="Ok"/>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -28,9 +28,9 @@ class LiteralEncodingTest extends AnyWordSpec {
       val string = XmlEncoder[Foo].encode(Foo("Ok"))
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
             | <foo><status>Ok</status></foo>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -41,9 +41,9 @@ class LiteralEncodingTest extends AnyWordSpec {
       val string = XmlEncoder[Foo].encode(Foo("Ok"))
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
             | <foo>Ok</foo>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
   }

--- a/modules/core/src/test/scala-3/ru/tinkoff/phobos/DerivationTest.scala
+++ b/modules/core/src/test/scala-3/ru/tinkoff/phobos/DerivationTest.scala
@@ -27,7 +27,7 @@ class DerivationTest extends AnyWordSpec with Matchers {
                    """.stripMargin.minimized
 
       val encoded = XmlEncoder[Bar].encode(bar)
-      assert(encoded == string)
+      assert(encoded == Right(string))
     }
   }
 

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/AutoDerivationTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/AutoDerivationTest.scala
@@ -71,7 +71,7 @@ class AutoDerivationTest extends AnyWordSpec with Matchers {
        |""".stripMargin
 
       val encoder = XmlEncoder.fromElementEncoder[Baz]("baz")
-      assert(encoder.encode(baz) == bazXml.minimized)
+      assert(encoder.encode(baz) == Right(bazXml.minimized))
 
       val decoder = XmlDecoder.fromElementDecoder[Baz]("baz")
       assert(decoder.decode(bazXml) == Right(baz))

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/DecoderDerivationTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/DecoderDerivationTest.scala
@@ -161,20 +161,25 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       val decodedResultInvalidFoo   = XmlDecoder[Wrapper].decode(invalidXmlStringAtFoo)
       val decodedResultInvalidTotal = XmlDecoder[Wrapper].decode(totallyInvalidXml)
 
-      assert(
-        decodedResultInvalidFoo == Left(
-          DecodingError(
-            "Unexpected end tag: expected </foo>\n at [row,col {unknown-source}]: [3,8]",
-            List("foo", "foo", "Wrapper"),
-          ),
-        ),
-      )
+      decodedResultInvalidFoo should matchPattern {
+        case Left(
+              DecodingError(
+                "Unexpected end tag: expected </foo>\n at [row,col {unknown-source}]: [3,8]",
+                List("foo", "foo", "Wrapper"),
+                _,
+              ),
+            ) =>
+      }
 
-      assert(
-        decodedResultInvalidTotal == Left(
-          DecodingError("Unexpected character 'L' (code 76) in prolog\n at [row,col {unknown-source}]: [1,2]", Nil),
-        ),
-      )
+      decodedResultInvalidTotal should matchPattern {
+        case Left(
+              DecodingError(
+                "Unexpected character 'L' (code 76) in prolog\n at [row,col {unknown-source}]: [1,2]",
+                Nil,
+                _,
+              ),
+            ) =>
+      }
     }
 
     def decodeNilValues(toList: String => List[Array[Byte]]): Assertion = {
@@ -813,7 +818,7 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
           barDecoder.decodeFromIterable(toList(string2)) == Right(bar2) &&
           barDecoder.decodeFromIterable(toList(string3)) == Right(bar3) &&
           barDecoder.decodeFromIterable(toList(string4)) ==
-          Left(DecodingError("Unknown type discriminator value: 'Qux'", List("foo", "bar"))),
+          Left(DecodingError("Unknown type discriminator value: 'Qux'", List("foo", "bar"), None)),
       )
     }
 
@@ -1060,7 +1065,7 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       animalXmlDecoder.decode(catString) shouldBe Right(Cat("meow"))
       animalXmlDecoder.decode(dogString) shouldBe Right(Dog(1234))
       animalXmlDecoder.decode(robotString) shouldBe
-        Left(DecodingError("Unknown type discriminator value: 'robot'", List("robot")))
+        Left(DecodingError("Unknown type discriminator value: 'robot'", List("robot"), None))
     }
 
     "override element name with discriminator in xml decoder if configured sync" in
@@ -1458,9 +1463,9 @@ class DecoderDerivationTest extends AnyWordSpec with Matchers {
       val decoded2 = XmlDecoder[Bar].decode(string2)
 
       assert(
-        decoded1 == Left(DecodingError("Invalid local name. Expected 'bar', but found 'wrong'", List("wrong"))) &&
+        decoded1 == Left(DecodingError("Invalid local name. Expected 'bar', but found 'wrong'", List("wrong"), None)) &&
           decoded2 == Left(
-            DecodingError("Invalid namespace. Expected 'tinkoff.ru', but found 'tcsbank.ru'", List("bar")),
+            DecodingError("Invalid namespace. Expected 'tinkoff.ru', but found 'tcsbank.ru'", List("bar"), None),
           ),
       )
     }

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/EncoderDerivationTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/EncoderDerivationTest.scala
@@ -27,7 +27,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = xmlEncoder.encode(bar)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <bar>
             |   <d>d value</d>
@@ -38,7 +38,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |   </foo>
             |   <e>e</e>
             | </bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -53,7 +53,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <bar e="e">
             |   <d>d value</d>
@@ -62,7 +62,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |     <c>3.0</c>
             |   </foo>
             | </bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -87,13 +87,13 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val xml = XmlEncoder[Qux].encode(qux)
       assert(
         xml ==
-          """
+          Right("""
           | <?xml version='1.0' encoding='UTF-8'?>
           | <qux>
           |   <str>constant</str>
           |   <foo bar="a74153b">text</foo>
           | </qux>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -108,7 +108,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val xml2 = XmlEncoder[Wrapper].encode(Wrapper(None))
       assert(
         xml1 ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <Wrapper>
             |   <foo b="b">
@@ -116,12 +116,12 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |     <c>2.0</c>
             |   </foo>
             | </Wrapper>
-          """.stripMargin.minimized &&
+          """.stripMargin.minimized) &&
           xml2 ==
-          """
+          Right("""
               | <?xml version='1.0' encoding='UTF-8'?>
               | <Wrapper/>
-            """.stripMargin.minimized,
+            """.stripMargin.minimized),
       )
     }
 
@@ -145,7 +145,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val xml2 = XmlEncoder[Foos].encode(bar2)
       assert(
         xml1 ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <foos>
             |   <foo b="b value">
@@ -163,12 +163,12 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |     <a>4</a>
             |   </foo>
             | </foos>
-          """.stripMargin.minimized
+          """.stripMargin.minimized)
           && xml2 ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <foos/>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -181,9 +181,9 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Foo].encode(foo)
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
             | <foo>Zm9vYmFy</foo>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -198,14 +198,14 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <bar>
             |   <d>d value</d>
             |   <foo a="1" b="b value">3.0</foo>
             |   <e>e</e>
             | </bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -224,7 +224,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Foo].encode(foo)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <foo>
             |    <foo>
@@ -241,7 +241,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |    </foo>
             |    <das>0</das>
             | </foo>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -254,10 +254,10 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Foo].encode(foo)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <foo>Sending item to <count>1</count><buz>Buzz</buz></foo>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -270,12 +270,12 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Foo].encode(foo)
       assert(
         string ==
-          """
+          Right("""
              | <?xml version='1.0' encoding='UTF-8'?>
              | <foo baz="Esca&quot;&apos;&lt;>&amp;pe">
              |   <bar>Esca"'&lt;>&amp;pe</bar>
              | </foo>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -290,7 +290,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <bar>
             |   <d>d value</d>
@@ -301,7 +301,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |   </theFoo>
             |   <e>e</e>
             | </bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -314,13 +314,13 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Foo].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             |   <foo theB="b value">
             |     <a>1</a>
             |     <c>3.0</c>
             |   </foo>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -335,14 +335,14 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <bar>
             |   <d>d value</d>
             |   <foo a="1" theB="b value">3.0</foo>
             |   <e>e</e>
             | </bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -358,14 +358,14 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             |<?xml version='1.0' encoding='UTF-8'?>
             | <Bar>
             |   <SomeTopName>d value</SomeTopName>
             |   <SomeFoo SomeName="1" SomeOther="b value">3.0</SomeFoo>
             |   <E>e</E>
             | </Bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -381,14 +381,14 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             |<?xml version='1.0' encoding='UTF-8'?>
             | <bar>
             |   <some_top_name>d value</some_top_name>
             |   <some_foo some_name="1" some_other="b value">3.0</some_foo>
             |   <e>e</e>
             | </bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -417,8 +417,8 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
           | </foo>
         """.stripMargin.minimized
 
-      assert(fooOptionEncoder.encode(fooOption) == fooOptionString)
-      assert(fooListEncoder.encode(fooList) == fooListString)
+      assert(fooOptionEncoder.encode(fooOption) == Right(fooOptionString))
+      assert(fooListEncoder.encode(fooList) == Right(fooListString))
     }
 
     "work for nested higher-kinded data" in {
@@ -460,8 +460,8 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
           | </bar>
         """.stripMargin.minimized
 
-      assert(barOptionEncoder.encode(barOption) == barOptionString)
-      assert(barListEncoder.encode(barList) == barListString)
+      assert(barOptionEncoder.encode(barOption) == Right(barOptionString))
+      assert(barListEncoder.encode(barList) == Right(barListString))
     }
   }
 
@@ -483,7 +483,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
       assert(
         string1 ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <bar>
             |   <d>d value</d>
@@ -492,9 +492,9 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |   </foo>
             |   <e>k</e>
             | </bar>
-          """.stripMargin.minimized &&
+          """.stripMargin.minimized) &&
           string2 ==
-          """
+          Right("""
               | <?xml version='1.0' encoding='UTF-8'?>
               | <bar>
               |   <d>d value</d>
@@ -503,9 +503,9 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
               |   </foo>
               |   <e>e</e>
               | </bar>
-          """.stripMargin.minimized &&
+          """.stripMargin.minimized) &&
           string3 ==
-          """
+          Right("""
               | <?xml version='1.0' encoding='UTF-8'?>
               | <bar>
               |   <d>another one value</d>
@@ -514,7 +514,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
               |   </foo>
               |   <e>v</e>
               | </bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -535,7 +535,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
       assert(
         string1 ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <qux>
             |   <d>d value</d>
@@ -544,9 +544,9 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |   </bar>
             |   <e>k</e>
             | </qux>
-          """.stripMargin.minimized &&
+          """.stripMargin.minimized) &&
           string2 ==
-          """
+          Right("""
               | <?xml version='1.0' encoding='UTF-8'?>
               | <qux>
               |   <d>d value</d>
@@ -555,9 +555,9 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
               |   </bar>
               |   <e>e</e>
               | </qux>
-          """.stripMargin.minimized &&
+          """.stripMargin.minimized) &&
           string3 ==
-          """
+          Right("""
               | <?xml version='1.0' encoding='UTF-8'?>
               | <qux>
               |   <d>another one value</d>
@@ -566,7 +566,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
               |   </bar>
               |   <e>v</e>
               | </qux>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
 
       case class Quux(d: String, baz: SealedClasses.Baz, e: Char)
@@ -585,7 +585,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
       assert(
         string4 ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <quux>
             |   <d>d value</d>
@@ -594,9 +594,9 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |   </baz>
             |   <e>k</e>
             | </quux>
-          """.stripMargin.minimized &&
+          """.stripMargin.minimized) &&
           string5 ==
-          """
+          Right("""
               | <?xml version='1.0' encoding='UTF-8'?>
               | <quux>
               |   <d>d value</d>
@@ -605,9 +605,9 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
               |   </baz>
               |   <e>e</e>
               | </quux>
-          """.stripMargin.minimized &&
+          """.stripMargin.minimized) &&
           string6 ==
-          """
+          Right("""
               | <?xml version='1.0' encoding='UTF-8'?>
               | <quux>
               |   <d>another one value</d>
@@ -616,7 +616,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
               |   </baz>
               |   <e>v</e>
               | </quux>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -628,23 +628,23 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
       assert(
         animalEncoder.encode(wolf) ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <animal xmlns:ans1="http://www.w3.org/2001/XMLSchema-instance" ans1:type="canis_lupus">
             |   <name>Igor</name>
             |   <strength>0.2</strength>
             |   <age>20</age>
             | </animal>
-          """.stripMargin.minimized &&
+          """.stripMargin.minimized) &&
           animalEncoder.encode(lion) ==
-          """
+          Right("""
               | <?xml version='1.0' encoding='UTF-8'?>
               | <animal xmlns:ans1="http://www.w3.org/2001/XMLSchema-instance" ans1:type="panthera_leo">
               |   <name>Sergey</name>
               |   <strength>0.75</strength>
               |   <speed>60.1</speed>
               | </animal>
-            """.stripMargin.minimized,
+            """.stripMargin.minimized),
       )
     }
 
@@ -656,21 +656,21 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
       assert(
         insectEncoder.encode(hornet) ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <insect xmlns:ans1="http://www.w3.org/2001/XMLSchema-instance" ans1:type="hornet">
             |   <name>Anton</name>
             |   <damage>200.123</damage>
             | </insect>
-          """.stripMargin.minimized &&
+          """.stripMargin.minimized) &&
           insectEncoder.encode(cockroach) ==
-          """
+          Right("""
               | <?xml version='1.0' encoding='UTF-8'?>
               | <insect xmlns:ans1="http://www.w3.org/2001/XMLSchema-instance" ans1:type="cockroach">
               |   <name>Dmitriy</name>
               |   <legsNumber>5</legsNumber>
               | </insect>
-            """.stripMargin.minimized,
+            """.stripMargin.minimized),
       )
     }
 
@@ -682,21 +682,21 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
       assert(
         fishEncoder.encode(clownFish) ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <fish xmlns:ans1="http://www.w3.org/2001/XMLSchema-instance" ans1:type="ClownFish">
             |   <name>Nemo</name>
             |   <finNumber>1</finNumber>
             | </fish>
-          """.stripMargin.minimized &&
+          """.stripMargin.minimized) &&
           fishEncoder.encode(whiteShark) ==
-          """
+          Right("""
               | <?xml version='1.0' encoding='UTF-8'?>
               | <fish xmlns:ans1="http://www.w3.org/2001/XMLSchema-instance" ans1:type="carcharodon_carcharias">
               |   <name>Bill</name>
               |   <teethNumber>20000000000</teethNumber>
               | </fish>
-            """.stripMargin.minimized,
+            """.stripMargin.minimized),
       )
     }
 
@@ -723,7 +723,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
           | </zoo>
                     """.stripMargin.minimized
       val zoo = Zoo(List(Cow(12.432), Cat("meow"), Dog(1234), Cat("nya")))
-      XmlEncoder[Zoo].encode(zoo) shouldBe string
+      XmlEncoder[Zoo].encode(zoo) shouldBe Right(string)
     }
 
     "override element name with discriminator in xml encoder if configured" in {
@@ -743,8 +743,8 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
           |  <woof>1234</woof>
           | </dog>
           |""".stripMargin.minimized
-      animalXmlEncoder.encode(cat) shouldBe catString
-      animalXmlEncoder.encode(dog) shouldBe dogString
+      animalXmlEncoder.encode(cat) shouldBe Right(catString)
+      animalXmlEncoder.encode(dog) shouldBe Right(dogString)
     }
   }
 
@@ -770,7 +770,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <ans1:bar xmlns:ans1="tinkoff.ru">
             |   <ans1:d>d value</ans1:d>
@@ -781,7 +781,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |   </ans1:foo>
             |   <ans1:e>e</ans1:e>
             | </ans1:bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -806,7 +806,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <ans1:bar xmlns:ans1="tinkoff.ru" ans1:e="e">
             |   <ans1:d>d value</ans1:d>
@@ -815,7 +815,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |     <ans1:c>3.0</ans1:c>
             |   </ans1:foo>
             | </ans1:bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -840,7 +840,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <bar e="e">
             |   <d>d value</d>
@@ -849,7 +849,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |     <ans1:c>3.0</ans1:c>
             |   </ans1:foo>
             | </bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -876,7 +876,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <ans1:bar xmlns:ans1="tcsbank.ru" e="e">
             |   <ans1:d>d value</ans1:d>
@@ -885,7 +885,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |     <ans2:c>3.0</ans2:c>
             |   </ans2:foo>
             | </ans1:bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -910,7 +910,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <ans1:Bar xmlns:ans1="tinkoff.ru">
             |   <ans1:SomeTopName>d value</ans1:SomeTopName>
@@ -920,7 +920,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |     <ans1:C>3.0</ans1:C>
             |   </ans1:SomeFoo>
             | </ans1:Bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -945,7 +945,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """
+          Right("""
             | <?xml version='1.0' encoding='UTF-8'?>
             | <ans1:bar xmlns:ans1="tinkoff.ru">
             |   <ans1:some_top_name>d value</ans1:some_top_name>
@@ -955,7 +955,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |     <ans1:c>3.0</ans1:c>
             |   </ans1:some_foo>
             | </ans1:bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -972,13 +972,13 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
             | <bar>
             |   <some_top_name>d value</some_top_name>
             |   <Me2 some_name="1" i-Have-priority="b value">3.0</Me2>
             |   <e>e</e>
             | </bar>
-          """.stripMargin.minimized,
+          """.stripMargin.minimized),
       )
     }
 
@@ -999,7 +999,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
           | <ans1:bar xmlns:ans1="tinkoff.ru" d="d value">
           |   <ans1:foo>
           |     <a>1</a>
@@ -1008,7 +1008,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
           |   </ans1:foo>
           |  <ans1:e>e</ans1:e>
           | </ans1:bar>
-      """.stripMargin.minimized,
+      """.stripMargin.minimized),
       )
     }
 
@@ -1031,7 +1031,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
             | <ans1:bar xmlns:ans1="tinkoff.ru" d="d value">
             |   <ans2:foo xmlns:ans2="tcsbank.ru">
             |     <a>1</a>
@@ -1040,7 +1040,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |   </ans2:foo>
             |  <ans1:e>e</ans1:e>
             | </ans1:bar>
-      """.stripMargin.minimized,
+      """.stripMargin.minimized),
       )
     }
 
@@ -1060,7 +1060,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
             | <ans1:bar xmlns:ans1="tinkoff.ru" ans1:d="d value" ans1:e="e">
             |   <foo>
             |     <a>1</a>
@@ -1068,7 +1068,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |     <c>3.0</c>
             |   </foo>
             | </ans1:bar>
-      """.stripMargin.minimized,
+      """.stripMargin.minimized),
       )
     }
 
@@ -1091,7 +1091,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
             | <ans1:bar xmlns:ans1="tinkoff.ru" ans1:d="d value" xmlns:ans2="tcsbank.ru" ans2:e="e">
             |   <foo>
             |     <a>1</a>
@@ -1099,7 +1099,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |     <c>3.0</c>
             |   </foo>
             | </ans1:bar>
-      """.stripMargin.minimized,
+      """.stripMargin.minimized),
       )
     }
 
@@ -1125,13 +1125,13 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
             | <foo xmlns:ans1="tcsbank.ru" xmlns:ans2="tinkoff.ru">
             |   <ans1:a>1</ans1:a>
             |   <ans1:b>b value</ans1:b>
             |   <ans1:c>3.0</ans1:c>
             | </foo>
-      """.stripMargin.minimized,
+      """.stripMargin.minimized),
       )
     }
 
@@ -1164,7 +1164,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
           | <ans1:bar xmlns:ans1="tinkoff.ru">
           |   <ans2:foo xmlns:ans2="tcsbank.ru" xmlns:ans3="example.com/3" xmlns:ans4="example.com/4" 
           |             xmlns:ans5="example.com/5" xmlns:ans6="example.com/6" xmlns:ans7="example.com/7" 
@@ -1174,7 +1174,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
           |     <c>3.0</c>
           |   </ans2:foo>
           | </ans1:bar>
-      """.stripMargin.minimized,
+      """.stripMargin.minimized),
       )
     }
 
@@ -1203,7 +1203,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
             | <ans1:bar xmlns:ans1="tinkoff.ru">
             |   <foo xmlns:ans2="tcsbank.ru">
             |     <a>1</a>
@@ -1211,7 +1211,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |     <c>3.0</c>
             |   </foo>
             | </ans1:bar>
-      """.stripMargin.minimized,
+      """.stripMargin.minimized),
       )
     }
 
@@ -1238,7 +1238,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
           |""".stripMargin.minimized
       val aquarium =
         Aquarium(List(SealedClasses.Amphiprion("Marlin", 3), SealedClasses.CarcharodonCarcharias("Jaws", 1234)))
-      XmlEncoder[Aquarium].encode(aquarium) shouldBe string
+      XmlEncoder[Aquarium].encode(aquarium) shouldBe Right(string)
     }
 
     "encode sealed traits using element names as discriminators" in {
@@ -1261,7 +1261,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
           | </shelter>
         """.stripMargin.minimized
       val animalShelter = AnimalShelter(List(Cat("meow"), Dog(1234)))
-      XmlEncoder[AnimalShelter].encode(animalShelter) shouldBe string
+      XmlEncoder[AnimalShelter].encode(animalShelter) shouldBe Right(string)
     }
 
     "encode namespaces with preferred prefixes" in {
@@ -1289,7 +1289,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
           | </tkf:foo>
         """.stripMargin.minimized
 
-      XmlEncoder[Foo].encode(foo) shouldBe string
+      XmlEncoder[Foo].encode(foo) shouldBe Right(string)
     }
 
     "declare namespaces with preferred prefixes from config" in {
@@ -1314,13 +1314,13 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
             | <foo xmlns:tcs="tcsbank.ru" xmlns:tkf="tinkoff.ru">
             |   <tcs:a>1</tcs:a>
             |   <tcs:b>b value</tcs:b>
             |   <tcs:c>3.0</tcs:c>
             | </foo>
-     """.stripMargin.minimized,
+     """.stripMargin.minimized),
       )
     }
 
@@ -1350,7 +1350,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
           | <bar xmlns="tinkoff.ru">
           |   <ans1:a xmlns:ans1="tcsbank.ru">123</ans1:a>
           |   <b>b value</b>
@@ -1369,7 +1369,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
           |     </qux>
           |   </foo>
           | </bar>
-          |""".stripMargin.minimized,
+          |""".stripMargin.minimized),
       )
     }
 
@@ -1399,7 +1399,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
       val string = XmlEncoder[Bar].encode(bar)
       assert(
         string ==
-          """<?xml version='1.0' encoding='UTF-8'?>
+          Right("""<?xml version='1.0' encoding='UTF-8'?>
             | <bar xmlns="tinkoff.ru">
             |   <ans1:a xmlns:ans1="tcsbank.ru">123</ans1:a>
             |   <b>b value</b>
@@ -1410,7 +1410,7 @@ class EncoderDerivationTest extends AnyWordSpec with Matchers {
             |     <f>4.321</f>
             |   </foo>
             | </bar>
-            |""".stripMargin.minimized,
+            |""".stripMargin.minimized),
       )
     }
   }

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/XmlEncoderTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/XmlEncoderTest.scala
@@ -12,7 +12,7 @@ class XmlEncoderTest extends AnyWordSpec with Matchers {
       implicit val fooEncoder: XmlEncoder[Foo] = deriveXmlEncoder("Foo")
 
       XmlEncoder[Foo].encodeWithConfig(Foo(1, "abc", 1.0), XmlEncoder.defaultConfig.withoutProlog) shouldBe
-        "<Foo><a>1</a><b>abc</b><c>1.0</c></Foo>"
+        Right("<Foo><a>1</a><b>abc</b><c>1.0</c></Foo>")
     }
 
     "not ignore prolog by default" in {
@@ -20,7 +20,7 @@ class XmlEncoderTest extends AnyWordSpec with Matchers {
       implicit val fooEncoder: XmlEncoder[Foo] = deriveXmlEncoder("Foo")
 
       XmlEncoder[Foo].encodeWithConfig(Foo(1, "abc", 1.0), XmlEncoder.defaultConfig) shouldBe
-        "<?xml version='1.0' encoding='UTF-8'?><Foo><a>1</a><b>abc</b><c>1.0</c></Foo>"
+        Right("<?xml version='1.0' encoding='UTF-8'?><Foo><a>1</a><b>abc</b><c>1.0</c></Foo>")
     }
 
     "overwrite prolog information if configured" in {
@@ -28,7 +28,7 @@ class XmlEncoderTest extends AnyWordSpec with Matchers {
       implicit val fooEncoder: XmlEncoder[Foo] = deriveXmlEncoder("Foo")
 
       XmlEncoder[Foo].encodeWithConfig(Foo(1, "abc", 1.0), XmlEncoder.XmlEncoderConfig("UTF-16", "1.1", true)) shouldBe
-        "<?xml version='1.1' encoding='UTF-16'?><Foo><a>1</a><b>abc</b><c>1.0</c></Foo>"
+        Right("<?xml version='1.1' encoding='UTF-16'?><Foo><a>1</a><b>abc</b><c>1.0</c></Foo>")
     }
   }
 }

--- a/modules/enumeratum/src/main/scala/ru/tinkoff/phobos/enumeratum/XmlEnum.scala
+++ b/modules/enumeratum/src/main/scala/ru/tinkoff/phobos/enumeratum/XmlEnum.scala
@@ -11,7 +11,7 @@ trait XmlEnum[A <: EnumEntry] { this: Enum[A] =>
 
   def decodeFromString(history: List[String], str: String): Either[DecodingError, A] = this.withNameOption(str) match {
     case Some(member) => Right(member)
-    case _            => Left(DecodingError(s"'$str' in not a member of enum $this", history))
+    case _            => Left(DecodingError(s"'$str' in not a member of enum $this", history, None))
   }
 
   implicit val enumElementDecoder: ElementDecoder[A]     = ElementDecoder.stringDecoder.emap(decodeFromString)

--- a/modules/enumeratum/src/test/scala/ru/tinkoff/phobos/enumeratum/EnumeratumTest.scala
+++ b/modules/enumeratum/src/test/scala/ru/tinkoff/phobos/enumeratum/EnumeratumTest.scala
@@ -34,45 +34,49 @@ class EnumeratumTest extends AnyWordSpec with Matchers {
       val xml2 = XmlEncoder[Bar].encode(bar2)
       val xml3 = XmlEncoder[Bar].encode(bar3)
       val xml4 = XmlEncoder[Baz].encode(baz)
+      val string1 =
+        """
+          | <?xml version='1.0' encoding='UTF-8'?>
+          | <bar>
+          |   <d>d value</d>
+          |   <foo>
+          |     Foo1
+          |   </foo>
+          |   <e>e</e>
+          | </bar>
+        """.stripMargin.minimized
+      val string2 =
+        """
+          | <?xml version='1.0' encoding='UTF-8'?>
+          | <bar>
+          |   <d>d value</d>
+          |   <foo>
+          |     Foo2
+          |   </foo>
+          |   <e>e</e>
+          | </bar>
+        """.stripMargin.minimized
+      val string3 =
+        """
+          | <?xml version='1.0' encoding='UTF-8'?>
+          | <bar>
+          |   <d>another one value</d>
+          |   <foo>
+          |     Foo3
+          |   </foo>
+          |   <e>v</e>
+          | </bar>
+        """.stripMargin.minimized
+      val string4 =
+        """
+          | <?xml version='1.0' encoding='UTF-8'?>
+          | <baz f="Foo1">Foo2</baz>
+        """.stripMargin.minimized
       assert(
-        xml1 ==
-          """
-              | <?xml version='1.0' encoding='UTF-8'?>
-              | <bar>
-              |   <d>d value</d>
-              |   <foo>
-              |     Foo1
-              |   </foo>
-              |   <e>e</e>
-              | </bar>
-            """.stripMargin.minimized &&
-          xml2 ==
-          """
-                | <?xml version='1.0' encoding='UTF-8'?>
-                | <bar>
-                |   <d>d value</d>
-                |   <foo>
-                |     Foo2
-                |   </foo>
-                |   <e>e</e>
-                | </bar>
-              """.stripMargin.minimized &&
-          xml3 ==
-          """
-                | <?xml version='1.0' encoding='UTF-8'?>
-                | <bar>
-                |   <d>another one value</d>
-                |   <foo>
-                |     Foo3
-                |   </foo>
-                |   <e>v</e>
-                | </bar>
-              """.stripMargin.minimized &&
-          xml4 ==
-          """
-                | <?xml version='1.0' encoding='UTF-8'?>
-                | <baz f="Foo1">Foo2</baz>
-              """.stripMargin.minimized,
+        xml1 == Right(string1) &&
+          xml2 == Right(string2) &&
+          xml3 == Right(string3) &&
+          xml4 == Right(string4),
       )
     }
 

--- a/modules/fs2-ce2/src/test/scala/ru/tinkoff/phobos/test/ParseTest.scala
+++ b/modules/fs2-ce2/src/test/scala/ru/tinkoff/phobos/test/ParseTest.scala
@@ -73,12 +73,12 @@ class ParseTest extends AsyncWordSpec with Inspectors {
     xml.nestedRepetetive -> Vector(1, 2, 3, 4).map(Foo(_)).map(Right(_)),
     xml.nestedRepetetiveIcnludingOtherTags -> Vector(
       Right(Foo(1)),
-      Left(DecodingError("Invalid local name. Expected 'foo', but found 'bar'", List("bar", "sub", "root"))),
+      Left(DecodingError("Invalid local name. Expected 'foo', but found 'bar'", List("bar", "sub", "root"), None)),
       Right(Foo(2)),
       Right(Foo(3)),
       Right(Foo(4)),
       Right(Foo(5)),
-      Left(DecodingError("Invalid local name. Expected 'foo', but found 'bar'", List("bar", "sub", "root"))),
+      Left(DecodingError("Invalid local name. Expected 'foo', but found 'bar'", List("bar", "sub", "root"), None)),
     ),
   )
 

--- a/modules/fs2/src/test/scala/ru/tinkoff/phobos/test/ParseTest.scala
+++ b/modules/fs2/src/test/scala/ru/tinkoff/phobos/test/ParseTest.scala
@@ -77,12 +77,12 @@ class ParseTest extends AsyncWordSpec with Inspectors {
     xml.nestedRepetetive -> Vector(1, 2, 3, 4).map(Foo(_)).map(Right(_)),
     xml.nestedRepetetiveIcnludingOtherTags -> Vector(
       Right(Foo(1)),
-      Left(DecodingError("Invalid local name. Expected 'foo', but found 'bar'", List("bar", "sub", "root"))),
+      Left(DecodingError("Invalid local name. Expected 'foo', but found 'bar'", List("bar", "sub", "root"), None)),
       Right(Foo(2)),
       Right(Foo(3)),
       Right(Foo(4)),
       Right(Foo(5)),
-      Left(DecodingError("Invalid local name. Expected 'foo', but found 'bar'", List("bar", "sub", "root"))),
+      Left(DecodingError("Invalid local name. Expected 'foo', but found 'bar'", List("bar", "sub", "root"), None)),
     ),
   )
 

--- a/modules/refined/src/main/scala/ru/tinkoff/phobos/refined/decoding/DecodingInstances.scala
+++ b/modules/refined/src/main/scala/ru/tinkoff/phobos/refined/decoding/DecodingInstances.scala
@@ -53,6 +53,7 @@ trait DecodingInstances {
     DecodingError(
       s"Failed to verify $P refinement for value=$rawValue of raw type $T: $error",
       history,
+      None,
     )
   }
 }

--- a/modules/refined/src/test/scala/ru/tinkoff/phobos/refined/RefinedEncodersTest.scala
+++ b/modules/refined/src/test/scala/ru/tinkoff/phobos/refined/RefinedEncodersTest.scala
@@ -30,7 +30,7 @@ class RefinedEncodersTest extends AnyWordSpec with Matchers {
          | </test>
        """.stripMargin.minimized
 
-      XmlEncoder[Test].encode(value) shouldEqual expectedResult
+      XmlEncoder[Test].encode(value) shouldEqual Right(expectedResult)
     }
 
     "encode elements correctly" in {
@@ -47,7 +47,7 @@ class RefinedEncodersTest extends AnyWordSpec with Matchers {
          | </test>
         """.stripMargin.minimized
 
-      XmlEncoder[Test].encode(value) shouldEqual expectedResult
+      XmlEncoder[Test].encode(value) shouldEqual Right(expectedResult)
     }
 
     "encode text correctly" in {
@@ -58,16 +58,15 @@ class RefinedEncodersTest extends AnyWordSpec with Matchers {
 
       val qux = Qux("42", Foo(42, NonNegLong(1000L)))
       val xml = XmlEncoder[Qux].encode(qux)
-      assert(
-        xml ==
-          """
+      val string =
+        """
             | <?xml version='1.0' encoding='UTF-8'?>
             | <qux>
             |   <str>42</str>
             |   <foo bar="42">1000</foo>
             | </qux>
-          """.stripMargin.minimized,
-      )
+          """.stripMargin.minimized
+      assert(xml == Right(string))
     }
   }
 }


### PR DESCRIPTION
# Do not throw exceptions if illegal characters are encoded

Encoders for strings could throw exceptions if they were used to encode characters, that are not allowed in XML. This was confusing and unexpected behavior. Therefore now such characters are filtered out.
```scala
implicit val xmlEncoder: XmlEncoder[String] = XmlEncoder.fromElementEncoder[String]("string")
// Zero character is not allowed
xmlEncoder.encode("\u0000")
// Would throw, but now will output <string/>
```

# Return either from encoding methods

⚠️ This breaks backwards compatibility

Encoders can still throw exceptions, for example, if element name is incorrect, like "1stElement". To handle such errors encoder methods now return Either, not pure values. To keep old behavior `-Unsafe` methods were added.